### PR TITLE
Added missing interface argument.

### DIFF
--- a/xappt_qt/browser.py
+++ b/xappt_qt/browser.py
@@ -84,7 +84,7 @@ class XapptBrowser(QtWidgets.QMainWindow, Ui_Browser):
         tool_class = item.data(column, self.ROLE_TOOL_CLASS)
         interface = xappt.get_interface()
         self.interfaces.append(interface)
-        interface.invoke(tool_class())
+        interface.invoke(tool_class(interface=interface))
 
     def selection_changed(self):
         help_text = ""


### PR DESCRIPTION
Fixes an issue where running a Tool from the Browser would result in this error:
```
Traceback (most recent call last):
  File "C:\Users\a\git\xappt_qt\xappt_qt\browser.py", line 87, in item_activated
    interface.invoke(tool_class())
TypeError: __init__() missing 1 required keyword-only argument: 'interface'
```