### PR TITLE
Call widget_options_updated when building widget from parameter.

### DIFF
--- a/xappt_qt/gui/tool_page.py
+++ b/xappt_qt/gui/tool_page.py
@@ -80,6 +80,8 @@ class ToolPage(QtWidgets.QWidget):
             param.metadata['widget'] = widget  # this lets us avoid lambdas
             self.grid.addWidget(widget, i, 1)
 
+            self.widget_options_updated(param)
+
             param.on_choices_changed.add(self.update_tool_choices)
             param.on_value_changed.add(self.widget_value_updated)
             param.on_options_changed.add(self.widget_options_updated)


### PR DESCRIPTION
Calling `widget_options_updated` when building widgets from parameters allows the default options to be respected when the tool page is initialized.

```python
# Example Plugin
import xappt


@xappt.register_plugin
class MyPlugin(xappt.BaseTool):
    food = xappt.ParamString(default="doughnut", options={'enabled': False})

    def execute(self, **kwargs) -> int:
        return 0
```

**Old Behavior**
![before](https://user-images.githubusercontent.com/5904655/96038353-dc6d7980-0e1b-11eb-8aed-ac6ab8cd12d2.png)


**New Behavior**
![after](https://user-images.githubusercontent.com/5904655/96038305-cb246d00-0e1b-11eb-9712-4b5626131ab3.png)
