### PR TITLE
Headless mode

### DIFF
--- a/xappt_qt/__version__.py
+++ b/xappt_qt/__version__.py
@@ -1,2 +1,2 @@
-__version__ = "0.2.25"
+__version__ = "0.2.26"
 __build__ = "dev"

--- a/xappt_qt/browser.py
+++ b/xappt_qt/browser.py
@@ -132,6 +132,7 @@ def main(args) -> int:
     browser.show()
 
     app.setProperty(APP_PROPERTY_RUNNING, True)
+    app.setProperty(APP_PROPERTY_LAUNCHER, False)
     return app.exec_()
 
 

--- a/xappt_qt/browser.py
+++ b/xappt_qt/browser.py
@@ -9,6 +9,7 @@ import xappt
 
 import xappt_qt.config
 from xappt_qt.gui.ui.browser import Ui_Browser
+from xappt_qt.gui.utilities import center_widget
 from xappt_qt.gui.utilities.dark_palette import apply_palette
 from xappt_qt.gui.utilities.tray_icon import TrayIcon
 from xappt_qt.constants import *
@@ -86,14 +87,7 @@ class XapptBrowser(xappt.ConfigMixin, QtWidgets.QMainWindow, Ui_Browser):
 
     def set_window_position(self, x: int, y: int):
         if x < 0 or y < 0:
-            app = QtWidgets.QApplication.instance()
-            cursor_pos = QtGui.QCursor.pos()
-            screen = app.screenAt(cursor_pos)
-
-            screen_rect = screen.availableGeometry()
-            window_rect = QtCore.QRect(QtCore.QPoint(0, 0), self.frameSize().boundedTo(screen_rect.size()))
-            self.resize(window_rect.size())
-            self.move(screen_rect.center() - window_rect.center())
+            center_widget(self)
         else:
             self.move(x, y)
 

--- a/xappt_qt/constants.py
+++ b/xappt_qt/constants.py
@@ -8,6 +8,7 @@ __all__ = [
     'APP_PACKAGE_NAME',
     'APP_TITLE',
     'APP_PROPERTY_RUNNING',
+    'APP_PROPERTY_LAUNCHER',
     'APP_CONFIG_PATH',
 ]
 
@@ -16,4 +17,5 @@ APP_INTERFACE_NAME = "qt"
 APP_TITLE = "Xappt QT"
 APP_PACKAGE_NAME = safe_file_name(APP_TITLE)
 APP_PROPERTY_RUNNING = "running"
+APP_PROPERTY_LAUNCHER = "launcher"
 APP_CONFIG_PATH = xappt.user_data_path().joinpath(APP_PACKAGE_NAME)

--- a/xappt_qt/gui/tab_pages/tools.py
+++ b/xappt_qt/gui/tab_pages/tools.py
@@ -92,7 +92,14 @@ class ToolsTabPage(BaseTabPage, Ui_tabTools):
             return
         interface = xappt.get_interface()
         tool_instance = tool_class(interface=interface)
-        interface.invoke(tool_instance)
+        invoke_options = {
+            'auto_run': False,
+            'headless': False,
+        }
+        if hasattr(tool_instance, "headless") and tool_instance.headless:
+            invoke_options['auto_run'] = True
+            invoke_options['headless'] = True
+        interface.invoke(tool_instance, **invoke_options)
 
     def launch_tool_new_process(self, tool_class: Type[xappt.BaseTool]):
         tool_name = tool_class.name()

--- a/xappt_qt/gui/utilities/__init__.py
+++ b/xappt_qt/gui/utilities/__init__.py
@@ -1,0 +1,11 @@
+from PyQt5 import QtWidgets, QtGui, QtCore
+
+
+def center_widget(widget: QtWidgets.QWidget):
+    app = QtWidgets.QApplication.instance()
+    cursor_pos = QtGui.QCursor.pos()
+    screen = app.screenAt(cursor_pos)
+    screen_rect = screen.availableGeometry()
+    window_rect = QtCore.QRect(QtCore.QPoint(0, 0), widget.frameSize().boundedTo(screen_rect.size()))
+    widget.resize(window_rect.size())
+    widget.move(screen_rect.center() - window_rect.center())

--- a/xappt_qt/launcher.py
+++ b/xappt_qt/launcher.py
@@ -33,7 +33,14 @@ def main(argv) -> int:
     interface = xappt.get_interface()
     params = params_from_args(tool_class=tool_class, tool_args=unknowns)
     tool_instance = tool_class(interface=interface, **params)
-    interface.invoke(tool_instance, auto_run=options.auto_run)
+    invoke_options = {
+        'auto_run': options.auto_run,
+        'headless': False,
+    }
+    if hasattr(tool_instance, "headless") and tool_instance.headless:
+        invoke_options['auto_run'] = True
+        invoke_options['headless'] = True
+    interface.invoke(tool_instance, **invoke_options)
 
     return app.exec_()
 

--- a/xappt_qt/launcher.py
+++ b/xappt_qt/launcher.py
@@ -29,6 +29,7 @@ def main(argv) -> int:
     apply_palette(app)
 
     app.setProperty(APP_PROPERTY_RUNNING, True)
+    app.setProperty(APP_PROPERTY_LAUNCHER, True)
 
     interface = xappt.get_interface()
     params = params_from_args(tool_class=tool_class, tool_args=unknowns)


### PR DESCRIPTION
The runner dialog is still created, but never shown. The big exceptions are with the progress functions, where we have to keep track of whether or not we're headless and route things accordingly.

A simple working example tool:

```python
import time
import xappt


@xappt.register_plugin
class HeadlessTest(xappt.BaseTool):
    headless = True

    @classmethod
    def name(cls) -> str:
        return "headless-test"

    @classmethod
    def help(cls) -> str:
        return "Just a test to work out issues with headless mode."

    @classmethod
    def collection(cls) -> str:
        return "System"

    def execute(self, **kwargs) -> int:
        if not self.interface.ask("Continue?"):
            return 0
        self.interface.progress_start()
        for i in range(100):
            time.sleep(0.1)
            self.interface.progress_update(message=f"Message {i + 1:03d}", percent_complete=(i / 100))
        self.interface.progress_end()
        self.interface.message("Complete")
        return 0
```